### PR TITLE
 feat: gymnax-side change of passing config env kwargs as EnvParams 

### DIFF
--- a/gymnax/environments/classic_control/acrobot.py
+++ b/gymnax/environments/classic_control/acrobot.py
@@ -49,8 +49,8 @@ class EnvParams(environment.EnvParams):
 class Acrobot(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible version of Acrobot-v1 OpenAI gym environment."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self):
+        super().__init__()
         self.obs_shape = (6,)
 
     @property

--- a/gymnax/environments/classic_control/cartpole.py
+++ b/gymnax/environments/classic_control/cartpole.py
@@ -43,8 +43,8 @@ class CartPole(environment.Environment[EnvState, EnvParams]):
     Source: github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self):
+        super().__init__()
         self.obs_shape = (4,)
 
     @property

--- a/gymnax/environments/classic_control/continuous_mountain_car.py
+++ b/gymnax/environments/classic_control/continuous_mountain_car.py
@@ -41,9 +41,6 @@ class EnvParams(environment.EnvParams):
 class ContinuousMountainCar(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible  version of MountainCarContinuous-v0 OpenAI gym environment."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     @property
     def default_params(self) -> EnvParams:
         # Default environment parameters

--- a/gymnax/environments/classic_control/mountain_car.py
+++ b/gymnax/environments/classic_control/mountain_car.py
@@ -39,9 +39,6 @@ class EnvParams(environment.EnvParams):
 class MountainCar(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible  version of MountainCar-v0 OpenAI gym environment."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     @property
     def default_params(self) -> EnvParams:
         # Default environment parameters

--- a/gymnax/environments/classic_control/pendulum.py
+++ b/gymnax/environments/classic_control/pendulum.py
@@ -38,8 +38,8 @@ class EnvParams(environment.EnvParams):
 class Pendulum(environment.Environment[EnvState, EnvParams]):
     """JAX Compatible version of Pendulum-v0 OpenAI gym environment."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self):
+        super().__init__()
         self.obs_shape = (3,)
 
     @property

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -20,13 +20,11 @@ class EnvState:
 @struct.dataclass
 class EnvParams:
     max_steps_in_episode: int = 1
+    disable_autoreset: bool = False
 
 
 class Environment(Generic[TEnvState, TEnvParams]):  # object):
     """Jittable abstract base class for all gymnax Environments."""
-
-    def __init__(self, disable_autoreset: bool = False):
-        self.disable_autoreset = disable_autoreset
 
     @property
     def default_params(self) -> EnvParams:
@@ -49,7 +47,7 @@ class Environment(Generic[TEnvState, TEnvParams]):  # object):
         done = jnp.logical_or(termination, truncation)
         obs_re, state_re = self.reset_env(key_reset, params)
         # Auto-reset environment based on termination if not disable_autoreset
-        should_reset = jnp.logical_and(done, jnp.logical_not(self.disable_autoreset))
+        should_reset = jnp.logical_and(done, jnp.logical_not(params.disable_autoreset))
         state = jax.tree_map(
             lambda x, y: jax.lax.select(should_reset, x, y), state_re, state_st
         )


### PR DESCRIPTION
The proper way to pass environment arguments to gymnax environments is via `EnvParams`. This is the gymnax-side change to support passing Stoix' `config.env.kwargs` to the environment via `EnvParams`.

- We additionally revert https://github.com/p-doom/gymnax/commit/200f63f839796b55050ff4f25e12938a852de30a since we are not passing kwargs to `Environment` any more.